### PR TITLE
feat: global-accessible diff log

### DIFF
--- a/examples/basic-usage/BasicUsage.tsx
+++ b/examples/basic-usage/BasicUsage.tsx
@@ -45,7 +45,9 @@ const useAnotherStore = create<AnotherState>(
         ...state,
         anotherText: str,
       })),
-  }))
+  }), {
+    logDiffs: true,
+  })
 )
 
 function BasicUsage() {

--- a/packages/middleware/index.ts
+++ b/packages/middleware/index.ts
@@ -13,6 +13,7 @@
 import { trace } from '../core/index'
 import type { TraceOptions } from '../core/types'
 import type { StateCreator } from 'zustand/vanilla'
+import { isProduction } from './utils'
 
 // Augment ImportMeta to support Vite's environment variables
 declare global {
@@ -22,24 +23,6 @@ declare global {
       DEV?: boolean
     }
   }
-}
-
-/**
- * Detect if running in production environment
- * This tries multiple common patterns for detecting production
- */
-const isProduction = (): boolean => {
-  // Check for common environment variables
-  if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') {
-    return true
-  }
-
-  // Check for Vite's import.meta.env (will be replaced at build time)
-  if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.PROD === true) {
-    return true
-  }
-
-  return false
 }
 
 /**
@@ -82,8 +65,12 @@ export const zusound = <T extends object>(
   // Add diff logging if requested
   if (logDiffs) {
     const originalOnTrace = traceOptions.onTrace
+
+    // TODO:: we need to find a better way to do this
+    window['__zusound_logger__'] = []
+
     traceOptions.onTrace = traceData => {
-      console.log('[zusound] State changes:', traceData.diff)
+      window['__zusound_logger__'].push(traceData)
       if (originalOnTrace) {
         originalOnTrace(traceData)
       }

--- a/packages/middleware/utils.ts
+++ b/packages/middleware/utils.ts
@@ -1,0 +1,18 @@
+
+/**
+ * Detect if running in production environment
+ * This tries multiple common patterns for detecting production
+ */
+export const isProduction = (): boolean => {
+    // Check for common environment variables
+    if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') {
+        return true
+    }
+
+    // Check for Vite's import.meta.env (will be replaced at build time)
+    if (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.PROD === true) {
+        return true
+    }
+
+    return false
+}


### PR DESCRIPTION
Even the `logDiffs` feature is still TBD, need to access logs by global.window somehow. So added this for now.
This should be revisited later.