### PR TITLE
Fix trusted publishing runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          npm --version
 
       # ── Resolve & validate tag ─────────────────────────────────────────
       - name: Resolve release tag

--- a/docs/RELEASE_GATES.md
+++ b/docs/RELEASE_GATES.md
@@ -9,8 +9,12 @@ Zusound uses npm trusted publishing through GitHub Actions OIDC.
 - GitHub workflow: `.github/workflows/release.yml`
 - GitHub environment: `npm-publish`
 - GitHub permission required in release job: `id-token: write`
+- npm CLI required for trusted publishing: `>=11.5.1`
 - Default publish auth: OIDC (no token required on normal `main` release runs)
 - Optional fallback auth: repository `NPM_TOKEN` secret, used only via manual `workflow_dispatch` (`auth_mode=token`)
+
+Current GitHub-hosted Node 22 runners still default to npm `10.x`, so the release
+workflow explicitly upgrades npm before publishing.
 
 Note for local/manual `changeset version` runs: `@changesets/changelog-github` requires `GITHUB_TOKEN` in environment.
 GitHub Actions already provides built-in `${{ github.token }}`; you cannot create a secret named `GITHUB_TOKEN` because `GITHUB_` prefix is reserved.


### PR DESCRIPTION
## Summary
- upgrade npm to `>=11.5.1` in the release workflow for npm trusted publishing
- document the npm CLI requirement in release gates

## Why
Recent release attempts for `v0.2.3` showed GitHub Actions was running npm `10.9.4`, while npm trusted publishing now requires npm `11.5.1+`.

## Verification
- workflow_dispatch release retry reached publish with upgraded npm
- remaining failure is npm-side trusted publisher auth (`ENEEDAUTH`), not workflow runtime