### PR TITLE
fix: add zustand dependency to package.json and pnpm-lock.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "lint-staged": "^15.2.0",
     "prettier": "^3.2.4",
     "turbo": "^2.9.14",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "zustand": "^4.4.7"
   },
   "packageManager": "pnpm@10.34.5",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      zustand:
+        specifier: ^4.4.7
+        version: 4.5.7(@types/react@19.2.18)(react@19.2.8)
 
   examples:
     dependencies:


### PR DESCRIPTION
## Summary

- Describe what changed and why.

## Verification

- [x] I ran relevant local checks (lint/typecheck/test/build or demo checks).
- [x] If demo behavior changed, I validated scene flow and responsive behavior.

## API Docs Synchronization

- [ ] This PR changes public API/docs/examples/types.
- [ ] If yes, I synchronized demo API docs with canonical sources (`packages/zusound/src/types.ts`, `packages/zusound/README.md`) or marked N/A with reason.
- [ ] Demo API docs synchronized with canonical API docs.
